### PR TITLE
issue #1: add DELETE /organization/employee/{name}

### DIFF
--- a/docs/ard/ARD-0001-remove-employee.md
+++ b/docs/ard/ARD-0001-remove-employee.md
@@ -1,0 +1,47 @@
+# ARD-0001: Add DELETE /organization/employee/{name} endpoint
+
+**Issue**: #1
+**Branch**: issue-1-remove-employee
+**Date**: 2026-05-03
+**Type**: functional
+**Author**: Victor Cosqui
+
+---
+
+## REASON
+
+### Problem being solved
+
+The organization API has no targeted delete operation. The only mutation is `POST /organization`, which replaces the entire hierarchy. When an employee leaves, callers must re-POST the full structure — there is no way to remove a single person.
+
+### Why now?
+
+Roadmap item: needed to keep the organization up to date when an employee leaves.
+
+### Cost of not doing this
+
+GDPR restrictions on stale data and a contaminated/inaccurate hierarchy that reflects employees who have already left.
+
+### Why this approach over alternatives?
+
+- **Cascading delete (auto-reassign reports)**: ruled out — silently restructuring the hierarchy would hide the organizational gap; callers must explicitly reassign reports first to keep the hierarchy intentional.
+- **Soft delete / archive flag**: ruled out — the domain has no audit trail requirement and the added complexity is not justified now.
+- **Targeted delete with 400 guard on managed employees**: chosen — keeps the invariant explicit and forces callers to act deliberately.
+
+---
+
+## Change
+
+Four layers touched; no existing contracts broken:
+
+- **Domain** — `EmployeeNotFoundException` (new) and `Organization.removeEmployee()` (new). The method validates two invariants before mutating: employee must exist (throws `EmployeeNotFoundException`) and must have no direct reports (throws `IllegalOrganizationException`). Only then is the employee removed from the in-memory list and unlinked from its manager's `managed` list.
+- **Ports** — `OrganizationRepositoryPort.deleteByName()` (new output port method); `OrganizationUseCase.removeEmployee()` (new input port method).
+- **Infrastructure** — `EmployeeCrudRepository.deleteByName()` (Spring Data derived delete); `OrganizationRepositoryAdapter.deleteByName()` delegates straight to the CRUD repository.
+- **REST** — `DELETE /organization/employee/{name}` endpoint added to `OrganizationController`; `GlobalExceptionHandler` gains a 404 handler for `EmployeeNotFoundException`.
+
+## Consequences
+
+- **Trade-offs accepted**: callers must explicitly remove direct reports before deleting a manager. Cascading reassignment was ruled out as it would silently restructure the hierarchy.
+- **New risks**: none beyond what already exists — the domain guard and the 400/404 responses make the constraint visible to callers.
+- **Follow-up work**: no batch delete; no audit trail of removals. Both are out of scope for this issue.
+- **Metrics to watch**: 400 rate on DELETE (indicates callers not reassigning reports before deleting).

--- a/src/main/kotlin/com/company/organization/application/OrganizationApplicationService.kt
+++ b/src/main/kotlin/com/company/organization/application/OrganizationApplicationService.kt
@@ -21,4 +21,10 @@ class OrganizationApplicationService(
         organization.addEmployees(employeesMap)
         organizationRepository.save(organization)
     }
+
+    override fun removeEmployee(name: String) {
+        val organization = organizationRepository.load()
+        organization.removeEmployee(name)
+        organizationRepository.deleteByName(name)
+    }
 }

--- a/src/main/kotlin/com/company/organization/domain/EmployeeNotFoundException.kt
+++ b/src/main/kotlin/com/company/organization/domain/EmployeeNotFoundException.kt
@@ -1,0 +1,4 @@
+package com.company.organization.domain
+
+class EmployeeNotFoundException(name: String) :
+    RuntimeException("Employee '$name' not found")

--- a/src/main/kotlin/com/company/organization/domain/Organization.kt
+++ b/src/main/kotlin/com/company/organization/domain/Organization.kt
@@ -27,6 +27,16 @@ class Organization private constructor(
         verifySingleRoot()
     }
 
+    fun removeEmployee(name: String) {
+        val employee = _employees.find { it.name == name }
+            ?: throw EmployeeNotFoundException(name)
+        if (employee.managed.isNotEmpty())
+            throw IllegalOrganizationException(
+                "Cannot remove '$name': has ${employee.managed.size} direct report(s). Reassign them first.")
+        employee.manager?.managed?.remove(employee)
+        _employees.remove(employee)
+    }
+
     private fun findOrCreate(name: String): Employee {
         require(name.isNotBlank()) { "Employee name cannot be blank" }
         return _employees.firstOrNull { it.name == name }

--- a/src/main/kotlin/com/company/organization/domain/port/OrganizationRepositoryPort.kt
+++ b/src/main/kotlin/com/company/organization/domain/port/OrganizationRepositoryPort.kt
@@ -5,4 +5,5 @@ import com.company.organization.domain.Organization
 interface OrganizationRepositoryPort {
     fun load(): Organization
     fun save(organization: Organization)
+    fun deleteByName(name: String)
 }

--- a/src/main/kotlin/com/company/organization/domain/port/OrganizationUseCase.kt
+++ b/src/main/kotlin/com/company/organization/domain/port/OrganizationUseCase.kt
@@ -6,4 +6,5 @@ interface OrganizationUseCase {
     fun getRootEmployee(): Employee?
     fun getEmployee(name: String): Employee
     fun addEmployees(employeesMap: Map<String, String>)
+    fun removeEmployee(name: String)
 }

--- a/src/main/kotlin/com/company/organization/infrastructure/EmployeeCrudRepository.kt
+++ b/src/main/kotlin/com/company/organization/infrastructure/EmployeeCrudRepository.kt
@@ -4,4 +4,5 @@ import org.springframework.data.repository.CrudRepository
 
 interface EmployeeCrudRepository : CrudRepository<EmployeeJpaEntity, Long> {
     fun findByNameIs(name: String): EmployeeJpaEntity?
+    fun deleteByName(name: String)
 }

--- a/src/main/kotlin/com/company/organization/infrastructure/OrganizationRepositoryAdapter.kt
+++ b/src/main/kotlin/com/company/organization/infrastructure/OrganizationRepositoryAdapter.kt
@@ -32,6 +32,8 @@ class OrganizationRepositoryAdapter(
         return Organization.reconstitute(domainMap.values.toList())
     }
 
+    override fun deleteByName(name: String) = employeeCrudRepository.deleteByName(name)
+
     override fun save(organization: Organization) {
         val existingByName: Map<String, EmployeeJpaEntity> =
             employeeCrudRepository.findAll().associateBy { it.name }

--- a/src/main/kotlin/com/company/organization/rest/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/company/organization/rest/GlobalExceptionHandler.kt
@@ -1,6 +1,8 @@
 package com.company.organization.rest
 
+import com.company.organization.domain.EmployeeNotFoundException
 import com.company.organization.domain.IllegalOrganizationException
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.ResponseEntity.badRequest
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -12,4 +14,8 @@ class GlobalExceptionHandler {
     @ExceptionHandler(IllegalOrganizationException::class)
     fun handleIllegalOrganization(ex: IllegalOrganizationException): ResponseEntity<Map<String, String>> =
         badRequest().body(mapOf("error" to (ex.message ?: "Bad request")))
+
+    @ExceptionHandler(EmployeeNotFoundException::class)
+    fun handleNotFound(ex: EmployeeNotFoundException): ResponseEntity<Map<String, String>> =
+        ResponseEntity.status(HttpStatus.NOT_FOUND).body(mapOf("error" to (ex.message ?: "Not found")))
 }

--- a/src/main/kotlin/com/company/organization/rest/OrganizationController.kt
+++ b/src/main/kotlin/com/company/organization/rest/OrganizationController.kt
@@ -2,6 +2,8 @@ package com.company.organization.rest
 
 import com.company.organization.domain.port.OrganizationUseCase
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -22,5 +24,11 @@ class OrganizationController(val organization: OrganizationUseCase) {
     @GetMapping("/organization/employee/{employeeName}/management", produces = [APPLICATION_JSON_VALUE])
     fun getEmployeeManagement(@PathVariable employeeName: String): Map<String, Any> {
         return upstreamHierarchy(organization.getEmployee(employeeName))
+    }
+
+    @DeleteMapping("/organization/employee/{name}")
+    fun removeEmployee(@PathVariable name: String): ResponseEntity<Void> {
+        organization.removeEmployee(name)
+        return ResponseEntity.ok().build()
     }
 }

--- a/src/test/kotlin/com/company/organization/rest/IntegrationTests.kt
+++ b/src/test/kotlin/com/company/organization/rest/IntegrationTests.kt
@@ -98,4 +98,69 @@ class IntegrationTests {
         assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
         assertThat(response.body).containsKey("error")
     }
+
+    @Test
+    fun `DELETE leaf employee returns 200 and employee is removed from hierarchy`() {
+        client.post().uri("/organization")
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(mapOf("bob" to "alice"))
+            .retrieve().toBodilessEntity()
+
+        val deleteResponse = client.delete().uri("/organization/employee/bob")
+            .retrieve().toBodilessEntity()
+
+        assertThat(deleteResponse.statusCode).isEqualTo(HttpStatus.OK)
+
+        val getResponse = client.get().uri("/organization")
+            .retrieve().toEntity<Map<String, Any>>().body
+
+        assertThat(getResponse).doesNotContainKey("bob")
+    }
+
+    @Test
+    fun `DELETE employee with direct reports returns 400 with error message`() {
+        client.post().uri("/organization")
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(mapOf("bob" to "alice"))
+            .retrieve().toBodilessEntity()
+
+        val response = client.delete().uri("/organization/employee/alice")
+            .retrieve()
+            .onStatus({ it.is4xxClientError }) { _, _ -> }
+            .toEntity<Map<String, Any>>()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(response.body).containsKey("error")
+    }
+
+    @Test
+    fun `DELETE root employee with no direct reports returns 200 and organization is empty`() {
+        client.post().uri("/organization")
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(mapOf("bob" to "alice"))
+            .retrieve().toBodilessEntity()
+
+        client.delete().uri("/organization/employee/bob").retrieve().toBodilessEntity()
+
+        val deleteResponse = client.delete().uri("/organization/employee/alice")
+            .retrieve().toBodilessEntity()
+
+        assertThat(deleteResponse.statusCode).isEqualTo(HttpStatus.OK)
+
+        val getResponse = client.get().uri("/organization")
+            .retrieve().toEntity<Map<String, Any>>().body
+
+        assertThat(getResponse).isEmpty()
+    }
+
+    @Test
+    fun `DELETE unknown employee returns 404 with error message`() {
+        val response = client.delete().uri("/organization/employee/ghost")
+            .retrieve()
+            .onStatus({ it.is4xxClientError }) { _, _ -> }
+            .toEntity<Map<String, Any>>()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(response.body).containsKey("error")
+    }
 }


### PR DESCRIPTION
Leaf employees can now be removed individually. Employees with direct reports are rejected (400); unknown names return 404. Domain guards the invariants before the repository delete is called.